### PR TITLE
Speedup encoder

### DIFF
--- a/bencode.go
+++ b/bencode.go
@@ -21,12 +21,11 @@ func Marshal(v interface{}) ([]byte, error) {
 
 // MarshalTo returns bencode encoding of v written to dst.
 func MarshalTo(dst []byte, v interface{}) ([]byte, error) {
-	buf := bytes.NewBuffer(dst)
-	enc := &Encoder{buf: buf}
+	enc := &Encoder{buf: dst}
 	if err := enc.marshal(v); err != nil {
 		return nil, err
 	}
-	return buf.Bytes(), nil
+	return dst, nil
 }
 
 // Unmarshaler is the interface implemented by types


### PR DESCRIPTION
Thanks @quasilyte for the hint to try without `bytes.Buffer`.

```
goos: darwin
goarch: arm64
pkg: github.com/cristaloleg/benches/bencode
                        │ bench_old.txt │              bench.txt              │
                        │    sec/op     │   sec/op     vs base                │
_cristalhq_Marshal-10       597.5n ± 0%   534.6n ± 0%  -10.52% (p=0.000 n=10)
_cristalhq_MarshalTo-10     431.6n ± 0%   382.9n ± 0%  -11.26% (p=0.000 n=10)

                        │ bench_old.txt  │               bench.txt               │
                        │      B/op      │     B/op      vs base                 │
_cristalhq_Marshal-10      1024.0 ± 0%       976.0 ± 0%  -4.69% (p=0.000 n=10)
_cristalhq_MarshalTo-10     0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) 

                        │ bench_old.txt │              bench.txt               │
                        │   allocs/op   │ allocs/op   vs base                  │
_cristalhq_Marshal-10      4.000 ± 0%     3.000 ± 0%  -25.00% (p=0.000 n=10)
_cristalhq_MarshalTo-10    0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) 
```